### PR TITLE
Add a CHANGELOG, the one thing between this repo and conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+Entries for releases before this file existed are reconstructed from the
+release dates on [PyPI](https://pypi.org/project/outkast/#history) and are
+deliberately brief: the record of *what* changed in them was not kept at the
+time, and inventing one here would be worse than saying so.
+
+## [Unreleased]
+
+Version 1.0.1 is declared in `pyproject.toml` and has not been published.
+
+## [1.0.0] - 2025-10-07
+
+Modernization release, five years after 0.2.1.
+
+## [0.2.1] - 2020-08-27
+
+## [0.1.0] - 2020-02-16
+
+Initial release.
+
+[Unreleased]: https://github.com/appeler/outkast/compare/v.0.2.1...HEAD
+[1.0.0]: https://pypi.org/project/outkast/1.0.0/
+[0.2.1]: https://github.com/appeler/outkast/releases/tag/v.0.2.1
+[0.1.0]: https://pypi.org/project/outkast/0.1.0/


### PR DESCRIPTION
`preen check --strict` had exactly one gating finding on this repo — no `CHANGELOG.md`. With this it **exits 0**.

## On the contents

The entries for past releases are reconstructed from upload dates on [PyPI](https://pypi.org/project/outkast/#history) — 0.1.0 (2020-02-16), 0.2.1 (2020-08-27), 1.0.0 (2025-10-07) — and are deliberately thin. What changed in each was not recorded at the time, and a plausible-sounding invented history would be worse than the file saying so, which is what it does.

## Something you may want to look at

While writing it, three version sources disagree:

| source | says |
|---|---|
| `pyproject.toml` | `1.0.1` |
| PyPI latest | `1.0.0` |
| only git tag | `v.0.2.1` (2020) |

The `## [Unreleased]` section records that 1.0.1 is declared but unpublished. Not changed here — it may be deliberate, and it is not what preen was flagging.

## Verification

`preen check --strict` exit 0 · `ruff check` · `ruff format --check` · `pyright` 0 errors · **108 tests pass**.

Part of a fleet-wide conformance pass from gojiplus/py-canon.