### PR TITLE
Enforce preen in CI and close adoption follow-ups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,4 +19,5 @@ jobs:
     uses: gojiplus/py-canon/.github/workflows/reusable-ci.yml@v1
     with:
       wheel-import: outkast
-      coverage-floor: 85
+      coverage-floor: 90
+      run-preen: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,9 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "pandas>=3.0.5",
-    "pyarrow>=25",
+    # 19.0.0 cannot read the shipped artifact ("Repetition level histogram
+    # size mismatch" on files carrying size statistics); 18.x and 19.0.1+ can.
+    "pyarrow>=18,!=19.0.0",
 ]
 
 
@@ -84,7 +86,7 @@ select = [
 # D203/D213: the google convention the fleet standard picks. W191/D206/D300:
 # ruff's own docs list these as always incompatible with `ruff format`, which
 # the standard also runs.
-ignore = ["D203", "D213", "W191", "D206", "D300", "B008", "E501"]
+ignore = ["D203", "D213", "W191", "D206", "D300", "B008"]
 
 [tool.ruff.lint.pydocstyle]
 convention = "google"
@@ -95,7 +97,6 @@ convention = "google"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
-pythonpath = ["."]
 python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]

--- a/tests/test_artifact.py
+++ b/tests/test_artifact.py
@@ -4,18 +4,69 @@ from __future__ import annotations
 
 import hashlib
 import json
-from importlib import resources
+from importlib import resources, util
+from pathlib import Path
 
 import pandas as pd
+import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 
-from data.secc.build_runtime_table import build
 from outkast import get_secc_data_manifest, list_supported_states
 from outkast.secc_composition import (
     ARTIFACT_NAME,
     EXPECTED_MANIFEST_SHA256,
     MANIFEST_NAME,
 )
+
+
+def _load_build():
+    """Load build() from the repo-local build script, which is not a package."""
+    script = Path(__file__).resolve().parents[1] / "data" / "secc"
+    spec = util.spec_from_file_location(
+        "build_runtime_table", script / "build_runtime_table.py"
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.build
+
+
+build = _load_build()
+
+
+def test_artifact_schema_matches_build_runtime_table() -> None:
+    """The shipped Parquet carries the Arrow schema build_runtime_table writes.
+
+    The dictionary index width is not pinned: the builder writes int8 indices,
+    but pyarrow only restores the stored index width from ARROW:schema metadata
+    since 20.0; older supported readers surface int32 indices for the same file.
+    """
+    data_root = resources.files("outkast") / "data" / "secc"
+    with (data_root / ARTIFACT_NAME).open("rb") as stream:
+        schema = pq.read_table(stream).schema
+
+    expected_names = [
+        "state",
+        "birth_year",
+        "last_name",
+        "n_sc",
+        "n_st",
+        "n_other",
+        "total_support",
+    ]
+    assert schema.names == expected_names
+    assert all(not field.nullable for field in schema)
+
+    state = schema.field("state").type
+    assert pa.types.is_dictionary(state)
+    assert pa.types.is_integer(state.index_type)
+    assert state.value_type == pa.string()
+    assert schema.field("birth_year").type == pa.int16()
+    assert schema.field("last_name").type == pa.string()
+    for count_column in ("n_sc", "n_st", "n_other", "total_support"):
+        assert schema.field(count_column).type == pa.uint32()
 
 
 def test_manifest_and_artifact_hashes_are_immutable() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -611,7 +611,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "pandas", specifier = ">=3.0.5" },
-    { name = "pyarrow", specifier = ">=25" },
+    { name = "pyarrow", specifier = ">=18,!=19.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1012,23 +1012,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version < '3.12'" },
-    { name = "babel", marker = "python_full_version < '3.12'" },
-    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version < '3.12'" },
-    { name = "imagesize", marker = "python_full_version < '3.12'" },
-    { name = "jinja2", marker = "python_full_version < '3.12'" },
-    { name = "packaging", marker = "python_full_version < '3.12'" },
-    { name = "pygments", marker = "python_full_version < '3.12'" },
-    { name = "requests", marker = "python_full_version < '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1048,23 +1048,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster", marker = "python_full_version >= '3.12'" },
-    { name = "babel", marker = "python_full_version >= '3.12'" },
-    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
-    { name = "docutils", marker = "python_full_version >= '3.12'" },
-    { name = "imagesize", marker = "python_full_version >= '3.12'" },
-    { name = "jinja2", marker = "python_full_version >= '3.12'" },
-    { name = "packaging", marker = "python_full_version >= '3.12'" },
-    { name = "pygments", marker = "python_full_version >= '3.12'" },
-    { name = "requests", marker = "python_full_version >= '3.12'" },
-    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
-    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
-    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
+    { name = "alabaster" },
+    { name = "babel" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "docutils" },
+    { name = "imagesize" },
+    { name = "jinja2" },
+    { name = "packaging" },
+    { name = "pygments" },
+    { name = "requests" },
+    { name = "roman-numerals" },
+    { name = "snowballstemmer" },
+    { name = "sphinxcontrib-applehelp" },
+    { name = "sphinxcontrib-devhelp" },
+    { name = "sphinxcontrib-htmlhelp" },
+    { name = "sphinxcontrib-jsmath" },
+    { name = "sphinxcontrib-qthelp" },
+    { name = "sphinxcontrib-serializinghtml" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [


### PR DESCRIPTION
Closes out the conformance loop the py-canon adoption (#23) left open. `preen check --strict` passes on this branch.

## What changed

- **`run-preen: true`** added to the canon CI shim, so conformance is enforced on every run. Coverage floor ratcheted 85 → 90 (measured: 92%).
- **E501 un-ignored.** Ruff passes clean at line length 88 with no code changes — the long lines live under `data/`, which ruff already excludes, so the ignore was vestigial.
- **`pythonpath = ["."]` removed** from pytest config. It put the repo root back on `sys.path`, defeating the src layout; the one import it papered over (`from data.secc.build_runtime_table import build` in `tests/test_artifact.py`) is now an explicit `importlib` load of the non-package build script by file path.
- **Arrow dtype assertions added** (`test_artifact_schema_matches_build_runtime_table`): the shipped Parquet's schema is asserted to match `data/secc/build_runtime_table.py` — dictionary-encoded `state` with string values, `int16` birth_year, `uint32` counts, every field non-nullable. The dictionary *index width* is deliberately not pinned: the builder writes `int8` indices, but pyarrow only restores the stored width from `ARROW:schema` metadata since 20.0; pyarrow 18/19 surface `int32` for the same file.
- **pyarrow floor lowered `>=25` → `>=18,!=19.0.0`.** The code uses no API newer than 18 (`pd.read_parquet(engine="pyarrow")`, `pa.schema`, `pq.write_table`). Verified empirically against the shipped artifact: 18.0.0, 18.1.0, 19.0.1, 20.0.0 and 25.0.1 all read it; **19.0.0 alone fails** with `OSError: Repetition level histogram size mismatch` (a 19.0.0 reader bug with size statistics, fixed in 19.0.1), hence the exclusion. The full 55-test suite passes under both pyarrow 18.0.0 and the locked 25.0.1.

## Verification

- `preen check --strict`: all 22 checks pass
- `uv run pytest --cov -q`: 55 passed, coverage 92%
- `ruff format --check`, `ruff check`, `pyright`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)