### PR TITLE
Release 2.0.1: preen enforcement, corrected pyarrow floor

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Managed by copier — records template version for `copier update`. Do not edit.
-_commit: v1.0.1
+_commit: v1.1.0
 _src_path: gh:gojiplus/py-canon
 author_email: gsood07@gmail.com
 author_name: Gaurav Sood

--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -3,7 +3,7 @@ _commit: v1.1.0
 _src_path: gh:gojiplus/py-canon
 author_email: gsood07@gmail.com
 author_name: Gaurav Sood
-coverage_floor: 85
+coverage_floor: 90
 default_branch: master
 description: Look up disclosure-limited SECC surname-group composition
 needs_cli: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,7 +55,7 @@ Modernization release, five years after 0.2.1.
 
 Initial release.
 
-[Unreleased]: https://github.com/appeler/outkast/compare/v2.0.1...HEAD
+[Unreleased]: https://github.com/appeler/outkast/compare/v2.0.0...HEAD
 [2.0.1]: https://pypi.org/project/outkast/2.0.1/
 [1.0.0]: https://pypi.org/project/outkast/1.0.0/
 [0.2.1]: https://github.com/appeler/outkast/releases/tag/v.0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ time, and inventing one here would be worse than saying so.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-08-25
+
+`2.0.0` was tagged and built, but its PyPI upload was rejected because trusted
+publishing had not been configured; it never reached the index. `2.0.1` is that
+release plus a corrected dependency floor, and is the first 2.x on PyPI.
+
 ### Changed
 
 - Adopt the py-canon project structure, quality checks, and release workflow.
@@ -34,6 +40,10 @@ time, and inventing one here would be worse than saying so.
 - Include the reproducible artifact builder in the source distribution without
   including its historical source CSV.
 - Remove classifier, prediction, and individual-inference language.
+- Widen the pyarrow floor to `>=18,!=19.0.0`. `2.0.0` required `>=25`, which
+  excluded every working older release for no reason: 18.x and 19.0.1+ read the
+  shipped artifact, and only 19.0.0 cannot.
+- Raise the CI coverage floor to 90 and enforce `preen` conformance.
 
 ## [1.0.0] - 2025-10-07
 
@@ -45,7 +55,8 @@ Modernization release, five years after 0.2.1.
 
 Initial release.
 
-[Unreleased]: https://github.com/appeler/outkast/compare/v.0.2.1...HEAD
+[Unreleased]: https://github.com/appeler/outkast/compare/v2.0.1...HEAD
+[2.0.1]: https://pypi.org/project/outkast/2.0.1/
 [1.0.0]: https://pypi.org/project/outkast/1.0.0/
 [0.2.1]: https://github.com/appeler/outkast/releases/tag/v.0.2.1
 [0.1.0]: https://pypi.org/project/outkast/0.1.0/

--- a/README.rst
+++ b/README.rst
@@ -87,6 +87,11 @@ package does not distribute broader aggregates.
        birth_year=1949,
    )
 
+``list_supported_states`` returns the states the table covers, and
+``get_secc_data_manifest`` returns the manifest described below. Both are useful
+before a lookup, because a state or birth year outside the shipped universe
+abstains the whole frame with ``unsupported_context``.
+
 The appended fields are:
 
 * ``secc_count_sc``, ``secc_count_st``, and ``secc_count_other``

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "outkast"
-version = "2.0.0"
+version = "2.0.1"
 description = "Look up disclosure-limited SECC surname-group composition"
 readme = "README.rst"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -578,7 +578,7 @@ wheels = [
 
 [[package]]
 name = "outkast"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "pandas" },
@@ -1012,23 +1012,23 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version < '3.12'" },
+    { name = "babel", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version < '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version < '3.12'" },
+    { name = "imagesize", marker = "python_full_version < '3.12'" },
+    { name = "jinja2", marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version < '3.12'" },
+    { name = "pygments", marker = "python_full_version < '3.12'" },
+    { name = "requests", marker = "python_full_version < '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version < '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version < '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/50/a8c6ccc36d5eacdfd7913ddccd15a9cee03ecafc5ee2bc40e1f168d85022/sphinx-9.0.4.tar.gz", hash = "sha256:594ef59d042972abbc581d8baa577404abe4e6c3b04ef61bd7fc2acbd51f3fa3", size = 8710502, upload-time = "2025-12-04T07:45:27.343Z" }
 wheels = [
@@ -1048,23 +1048,23 @@ resolution-markers = [
     "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "alabaster" },
-    { name = "babel" },
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "docutils" },
-    { name = "imagesize" },
-    { name = "jinja2" },
-    { name = "packaging" },
-    { name = "pygments" },
-    { name = "requests" },
-    { name = "roman-numerals" },
-    { name = "snowballstemmer" },
-    { name = "sphinxcontrib-applehelp" },
-    { name = "sphinxcontrib-devhelp" },
-    { name = "sphinxcontrib-htmlhelp" },
-    { name = "sphinxcontrib-jsmath" },
-    { name = "sphinxcontrib-qthelp" },
-    { name = "sphinxcontrib-serializinghtml" },
+    { name = "alabaster", marker = "python_full_version >= '3.12'" },
+    { name = "babel", marker = "python_full_version >= '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.12' and sys_platform == 'win32'" },
+    { name = "docutils", marker = "python_full_version >= '3.12'" },
+    { name = "imagesize", marker = "python_full_version >= '3.12'" },
+    { name = "jinja2", marker = "python_full_version >= '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.12'" },
+    { name = "pygments", marker = "python_full_version >= '3.12'" },
+    { name = "requests", marker = "python_full_version >= '3.12'" },
+    { name = "roman-numerals", marker = "python_full_version >= '3.12'" },
+    { name = "snowballstemmer", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-applehelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-devhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-htmlhelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-jsmath", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-qthelp", marker = "python_full_version >= '3.12'" },
+    { name = "sphinxcontrib-serializinghtml", marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cd/bd/f08eb0f4eed5c83f1ba2a3bd18f7745a2b1525fad70660a1c00224ec468a/sphinx-9.1.0.tar.gz", hash = "sha256:7741722357dd75f8190766926071fed3bdc211c74dd2d7d4df5404da95930ddb", size = 8718324, upload-time = "2025-12-31T15:09:27.646Z" }
 wheels = [

--- a/uv.lock
+++ b/uv.lock
@@ -735,8 +735,8 @@ wheels = [
 
 [[package]]
 name = "py-canon"
-version = "1.0.1"
-source = { git = "https://github.com/gojiplus/py-canon?rev=v1#254362c2c0f5fc332216d455abfc2e3f89957282" }
+version = "1.1.0"
+source = { git = "https://github.com/gojiplus/py-canon?rev=v1#f756be7a6e4dd0ea2a006c215e39ed2e1e29a412" }
 
 [[package]]
 name = "pyarrow"


### PR DESCRIPTION
## Why

`2.0.0` was tagged and built on 18 Aug, but its PyPI upload was rejected — trusted publishing had not been configured on the project. It never reached the index. This is that release plus one real correction.

## What changed

- **`pyarrow>=18,!=19.0.0`**, replacing `>=25`. The old pin locked out every working older release for no reason: 18.x and 19.0.1+ read the shipped artifact, and only 19.0.0 hits the "Repetition level histogram size mismatch".
- CI coverage floor 85 → 90, and `run-preen: true`.
- `ruff` no longer ignores `E501`; `pytest` drops the `pythonpath` shim.
- Four added tests in `test_artifact.py`.
- README now documents `list_supported_states` and `get_secc_data_manifest`. `state` is required, and the landing page previously gave one example value with no way to discover the other eighteen.

## Verification

Local, on this branch: ruff clean, ruff format clean (10 files), pyright 0 errors, **55 tests passed**, `preen check --strict` all passed, `zizmor` no findings. `uv build` + `twine check` both PASSED; wheel metadata reports `2.0.1` and the corrected pin.

Released as `2.0.1` rather than re-cutting `2.0.0`, because the `v2.0.0` tag already has a public GitHub release with attached artifacts and moving it would rewrite that.